### PR TITLE
dactyl family: enable via

### DIFF
--- a/keyboards/bastardkb/scylla/keymaps/vendor/rules.mk
+++ b/keyboards/bastardkb/scylla/keymaps/vendor/rules.mk
@@ -1,0 +1,1 @@
+VIA_ENABLE = yes

--- a/keyboards/bastardkb/skeletyl/keymaps/vendor/rules.mk
+++ b/keyboards/bastardkb/skeletyl/keymaps/vendor/rules.mk
@@ -1,0 +1,1 @@
+VIA_ENABLE = yes

--- a/keyboards/bastardkb/tbkmini/keymaps/vendor/rules.mk
+++ b/keyboards/bastardkb/tbkmini/keymaps/vendor/rules.mk
@@ -1,0 +1,1 @@
+VIA_ENABLE = yes


### PR DESCRIPTION
Enables via on the `vendor` keymap for the dactyl family